### PR TITLE
bugfix end_time ColorDepthController

### DIFF
--- a/data/video_reader.py
+++ b/data/video_reader.py
@@ -143,7 +143,7 @@ class ColorDepthController:
         return max(self.depth_reader.start_time(), self.color_reader.start_time())
 
     def end_time(self):
-        return min(self.depth_reader.start_time(), self.color_reader.start_time())
+        return min(self.depth_reader.end_time(), self.color_reader.end_time())
 
     def get_closest_time(self, time):
         return self.depth_reader.get_closest_time(time)


### PR DESCRIPTION
This PR fixes a bug in ColorDepthController class, where the end time of a sequence was incorrectly calculated leading to a crash of the video2images tool when not using the -nodepth flag